### PR TITLE
Make clap an optional dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.5"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a1f23fa97e1d1641371b51f35535cb26959b8e27ab50d167a8b996b5bada819"
+checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -234,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.5"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdc5d93c358224b4d6867ef1356d740de2303e9892edc06c5340daeccd96bab"
+checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1216,7 +1216,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cities-json",
- "clap 4.2.5",
+ "clap 4.2.7",
  "criterion",
  "geometry-rs",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.4.0"
 [dependencies]
 anyhow = "1"
 bytes = "1"
-clap = {version = "4.2.5", features = ["color", "help", "usage", "derive"]}
+clap = {version = "4.2.5", features = ["color", "help", "usage", "derive"], optional = true}
 lazy_static = "1.4.0"
 prost = "0.11"
 rand = "0.8.5"
@@ -31,6 +31,14 @@ cities-json = "0.3.6"
 
 [dev-dependencies]
 criterion = {version = "0.4", features = ["html_reports"]}
+
+[features]
+default = ["clap"]
+
+[[bin]]
+name = "tzf"
+required-features = ["clap"]
+doc = false
 
 [[bench]]
 harness = false

--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@
 - Geometry: use <https://github.com/ringsaturn/geometry-rs> which is
   <https://github.com/tidwall/geometry>'s Rust port.
 
+## Build options
+
+By default, the binary is built as well. If you don't want/need it, then build like this:
+
+```bash
+> cargo build --no-default-features
+```
+
+Or put in your `Cargo.toml` file:
+
+```toml
+tzf-rs = { version = "0.4.0", default-features = false }
+```
+
 ## Bindings
 
 - Ruby, see [tzf-rb](https://github.com/HarlemSquirrel/tzf-rb)

--- a/src/bin/tzf.rs
+++ b/src/bin/tzf.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "clap")]
+
 use clap::Parser;
 use tzf_rs::DefaultFinder;
 


### PR DESCRIPTION
I'd like to make clap an optional dependency if I just want to install the library, while also keeping the ability to use `cargo install` to install the binary.