### PR TITLE
add option to lookup multiple coordinates from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,18 @@ Rust port's Python binding; you can view it
 - Python, see [`ringsaturn/tzfpy`](https://github.com/ringsaturn/tzfpy)
 - Wasm, see [`ringsaturn/tzf-wasm`](https://github.com/ringsaturn/tzf-wasm)
 
+## Command line
+
+The binary helps in debugging tzf-rs and using it in (scripting) languages
+without bindings. Either specify the coordinates as parameters to get a single
+time zone, or to look up multiple coordinates efficiently specify the ordering
+and pipe them to the binary one pair of coordinates per line.
+
+```shell
+tzf --lng 116.3883 --lat 39.9289
+echo -e "116.3883 39.9289\n116.3883, 39.9289" | tzf --stdin-order lng-lat
+```
+
 ## LICENSE
 
 This project is licensed under the [MIT license](./LICENSE). The data is

--- a/src/bin/tzf.rs
+++ b/src/bin/tzf.rs
@@ -1,23 +1,69 @@
 #![cfg(feature = "clap")]
 
-use clap::Parser;
+use clap::{Args, Parser, ValueEnum};
+use std::error::Error;
+use std::io::{self, BufRead, Write};
 use tzf_rs::DefaultFinder;
 
 #[derive(Parser, Debug)]
 #[command(name = "tzf")]
 struct Cli {
-    /// longitude
+    #[command(flatten)]
+    params: Option<Params>,
+
+    /// Read multiple coordinates from stdin in given order
+    #[arg(long, conflicts_with("Params"))]
+    stdin_order: Option<StdinOrder>,
+}
+
+#[derive(Args, Debug)]
+struct Params {
+    /// Longitude
     #[arg(long, allow_negative_numbers(true), alias("lon"))]
     lng: f64,
 
-    /// latitude
+    /// Latitude
     #[arg(long, allow_negative_numbers(true))]
     lat: f64,
 }
 
-pub fn main() {
+#[derive(Clone, Debug, ValueEnum)]
+enum StdinOrder {
+    #[value(alias("lon-lat"))]
+    LngLat,
+    #[value(alias("lat-lon"))]
+    LatLng,
+}
+
+fn is_delimiter(c: char) -> bool {
+    matches!(c, ' ' | '\t' | ',' | ';')
+}
+
+pub fn main() -> Result<(), Box<dyn Error>> {
     let cli = Cli::parse();
     let finder = DefaultFinder::new();
-    let tz_name = finder.get_tz_name(cli.lng, cli.lat);
-    println!("{tz_name:?}");
+    if let Some(params) = cli.params {
+        println!("{:?}", finder.get_tz_name(params.lng, params.lat));
+    } else if let Some(stdin_order) = cli.stdin_order {
+        let (mut stdin, mut stdout) = (io::stdin().lock(), io::stdout().lock());
+        let mut line = String::new();
+        while stdin.read_line(&mut line)? != 0 && line.ends_with("\n") {
+            let mut iter = line.chars().skip(1);
+            let i = 1 + iter.position(is_delimiter).expect("Missing delimiter");
+            let j = i
+                + 1
+                + iter
+                    .position(|c| !is_delimiter(c))
+                    .expect("Missing second coordinate");
+            let k = line.len() - if line.ends_with("\r\n") { 2 } else { 1 };
+            let (a, b) = (line[0..i].parse::<f64>()?, line[j..k].parse::<f64>()?);
+            let (lng, lat) = match stdin_order {
+                StdinOrder::LngLat => (a, b),
+                StdinOrder::LatLng => (b, a),
+            };
+            writeln!(stdout, "{:?}", finder.get_tz_name(lng, lat))?;
+            line.clear();
+        }
+    }
+    Ok(())
 }


### PR DESCRIPTION
The binary is ideal for looking up a timezone in a script. However I needed to look up a lot of them (a few millions), for which the CLI is too slow because it requires starting a new process for each coordinate, which has to initialize the finder from scratch every time.

This MR adds a single extra option to the binary: `--stdin-order {lng-lat,lat-lng}`

It is mutually exclusive with providing a longitude and latitude as options on the command line. Instead, when the binary is started with this option it will read coordinates from the standard input, one coordinate per line, and print a line with the resulting timezone string.

I tried to keep it as contained as possible (only adding a single option, not changing any other source files than for the binary, not requiring any additional dependencies) while making it reasonably fast (reusing a finder, input buffering, avoiding unnecessary allocations).

Open to feedback!

EDIT: Re-pushed because I didn't stage and commit all my changes.