### PR TITLE
Fix empty result on shared polygon borders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "geometry-rs"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d6f6ee37dd57537a387bc9fefdc8274379faf3e5c6a81d8962c0eaa60f376e1"
+checksum = "794fbaf8ce24464265e001a7a1dc819e401a303127c0cb714538e21ebe077c77"
 dependencies = [
  "rtree_rs",
 ]
@@ -1251,7 +1251,7 @@ source = "git+https://github.com/ringsaturn/tzf-dist?rev=v0.0.2026-c-fix1#d9868c
 
 [[package]]
 name = "tzf-rs"
-version = "1.3.6"
+version = "1.3.7"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT"
 name = "tzf-rs"
 readme = "README.md"
 repository = "https://github.com/ringsaturn/tzf-rs"
-version = "1.3.6"
+version = "1.3.7"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -32,7 +32,7 @@ clap = {version = "4", features = [
   "usage",
   "derive",
 ], optional = true}
-geometry-rs = "0.5.0"
+geometry-rs = "0.5.1"
 prost = "0.14.1"
 serde = {version = "1.0.228", features = [
   "derive",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,12 @@ struct Item<T: CoordStorage> {
 impl<T: CoordStorage> Item<T> {
     fn contains_point(&self, p: &Point) -> bool {
         for poly in &self.polys {
-            if poly.contains_point(*p) {
+            // Timezone polygons tile the globe, so a query that lands exactly
+            // on a shared border must belong to both neighbours rather than to
+            // neither. The nautical zones make this easy to hit: their borders
+            // sit on whole meridians (7.5°, 22.5°, …), which is exactly the
+            // kind of coordinate people type by hand.
+            if poly.contains_point_allow_on_edge(*p) {
                 return true;
             }
         }

--- a/tests/border_test.rs
+++ b/tests/border_test.rs
@@ -1,0 +1,69 @@
+//! Regression tests for <https://github.com/ringsaturn/tzf-rs/issues/207>:
+//! a query landing exactly on a shared polygon border used to match neither
+//! neighbour and return an empty result.
+
+#[cfg(test)]
+mod tests {
+    use tzf_rs::{DefaultFinder, Finder};
+
+    #[test]
+    fn nautical_border_is_not_a_gap() {
+        let finder = DefaultFinder::new();
+
+        // The nautical zones are 15°-wide strips, so their borders sit on
+        // whole meridians. The two coordinates from the issue report:
+        for (lng, lat) in [(7.5, 54.5), (-22.5, 54.5)] {
+            assert!(
+                !finder.get_tz_name(lng, lat).is_empty(),
+                "get_tz_name({lng}, {lat}) is empty"
+            );
+            // Both sides of the border claim the point.
+            assert_eq!(
+                finder.get_tz_names(lng, lat).len(),
+                2,
+                "get_tz_names({lng}, {lat}) = {:?}",
+                finder.get_tz_names(lng, lat)
+            );
+        }
+
+        assert_eq!(finder.get_tz_names(7.5, 54.5), ["Etc/GMT-1", "Etc/GMT"]);
+        assert_eq!(finder.get_tz_names(-22.5, 54.5), ["Etc/GMT+1", "Etc/GMT+2"]);
+    }
+
+    #[test]
+    fn border_neighbours_still_resolve_to_one_side_each() {
+        let finder = DefaultFinder::new();
+
+        assert_eq!(finder.get_tz_name(7.4999, 54.5), "Etc/GMT");
+        assert_eq!(finder.get_tz_name(7.5001, 54.5), "Etc/GMT-1");
+        assert_eq!(finder.get_tz_name(-22.4999, 54.5), "Etc/GMT+1");
+        assert_eq!(finder.get_tz_name(-22.5001, 54.5), "Etc/GMT+2");
+    }
+
+    /// A 1°×1° sweep of the whole globe. Every point used to miss on the 24
+    /// nautical meridians (2753 empty results); nothing may miss now.
+    #[test]
+    fn global_grid_has_no_holes() {
+        let finder = Finder::new();
+
+        let mut empty: Vec<(f64, f64)> = vec![];
+        let mut lng = -179.5;
+        while lng <= 179.5 {
+            let mut lat = -89.5;
+            while lat <= 89.5 {
+                if finder.get_tz_name(lng, lat).is_empty() {
+                    empty.push((lng, lat));
+                }
+                lat += 1.0;
+            }
+            lng += 1.0;
+        }
+
+        assert!(
+            empty.is_empty(),
+            "{} empty results, first few: {:?}",
+            empty.len(),
+            &empty[..empty.len().min(10)]
+        );
+    }
+}


### PR DESCRIPTION
geometry-rs reports a point lying exactly on a polygon's exterior as outside, so a query landing on a border between two timezones matched neither of them and returned "". The nautical zones make this easy to hit: they are 15°-wide strips whose borders sit on whole meridians (7.5°, 22.5°, …), exactly the kind of coordinate people type by hand.

Switch Item::contains_point to the new
Polygon::contains_point_allow_on_edge (geometry-rs 0.5.1), which makes a border belong to both neighbours instead of neither. get_tz_names now returns both zones there; get_tz_name returns the first match in the grid index order.

Measured on a global 1° grid (lat/lng at .5 offsets): 2753 of 64800 queries returned "" before, all of them on the 24 nautical meridians; 0 do now. Every non-border result is unchanged, and a deterministic sweep of the cities-json dataset shows no latency change (DefaultFinder ~203 ns/op, Finder ~6.8 µs/op before and after).

Fixes #207